### PR TITLE
feat: add Conversation and ConversationParticipant entities

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { UsersModule } from './users/users.module';
 import { UserSeedService } from './database/seeds/user.seed';
 import { ConsoleModule } from 'nestjs-console';
 import { AuthModule } from './auth/auth.module';
+import { ConversionModule } from './conversion/conversion.module';
 
 @Module({
   imports: [
@@ -19,7 +20,8 @@ import { AuthModule } from './auth/auth.module';
     TypeOrmModule.forRoot(typeormConfig),
     TypeOrmModule.forFeature([User]),
     UsersModule,
-    AuthModule
+    AuthModule,
+    ConversionModule,
   ],
   providers: [SeedCommand, UserSeedService],
 })

--- a/src/conversion/conversion.module.ts
+++ b/src/conversion/conversion.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class ConversionModule {}

--- a/src/conversion/emuns/conversionTypes.ts
+++ b/src/conversion/emuns/conversionTypes.ts
@@ -1,0 +1,4 @@
+export enum ConversationType {
+    DIRECT = 'direct',
+    GROUP = 'group',
+  }  

--- a/src/conversion/entity/conversationParticipant.ts
+++ b/src/conversion/entity/conversationParticipant.ts
@@ -1,0 +1,15 @@
+import { Conversation } from 'src/conversion/entity/conversion.entity';
+import { User } from 'src/users/entities/user.entity';
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+
+@Entity()
+export class ConversationParticipant {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Conversation, (conversation) => conversation.participants, { onDelete: 'CASCADE' })
+  conversation: Conversation;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+}

--- a/src/conversion/entity/conversion.entity.ts
+++ b/src/conversion/entity/conversion.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+import { ConversationType } from '../emuns/conversionTypes';
+import { ConversationParticipant } from 'src/conversion/entity/conversationParticipant';
+
+@Entity()
+export class Conversation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: ConversationType })
+  type: ConversationType;
+
+  @Column({ nullable: true }) // Only needed for group chats
+  title?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(() => ConversationParticipant, (participant) => participant.conversation, { cascade: true })
+  participants: ConversationParticipant[];
+}


### PR DESCRIPTION
This PR introduces the Conversation and ConversationParticipant entities to support both direct and group conversations. The following changes have been made:

Created the Conversation entity with fields: id, type, title, createdAt, and updatedAt.

Implemented an enum ConversationType to distinguish between DIRECT and GROUP conversations.

Established a many-to-many relationship using the ConversationParticipant entity.

Set up TypeORM configurations and added migrations for database persistence.

closses issue #11